### PR TITLE
Makefile: Use lgomp flag only if compiled with LLD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -721,7 +721,9 @@ POLLY_FLAGS	:= -mllvm -polly \
 		   -mllvm -polly-run-dce \
 		   -mllvm -polly-run-inliner \
 		   -mllvm -polly-opt-fusion=max \
-		   -mllvm -polly-parallel -lgomp \
+		   ifeq ($(ld-name),lld)
+                   -mllvm -polly-parallel -lgomp \
+		   endif
 		   -mllvm -polly-ast-use-context \
 		   -mllvm -polly-detect-keep-going \
 		   -mllvm -polly-vectorizer=stripmine \


### PR DESCRIPTION
Using lgomp flag without lld causes errors